### PR TITLE
Make it so Get-CACertFromSystem works in PowerShell Core

### DIFF
--- a/PhpManager/private/Get-CACertFromSystem.ps1
+++ b/PhpManager/private/Get-CACertFromSystem.ps1
@@ -1,5 +1,4 @@
-﻿function Get-CACertFromSystem
-{
+﻿function Get-CACertFromSystem {
     <#
     .Synopsis
     Get the root CA Certificates from the Windows store
@@ -20,68 +19,58 @@
         if ($certs.length -eq 0) {
             throw "No certificates found in $certsPath"
         }
-        $tempDirectory = New-TempDirectory
+        $stream = New-Object System.IO.MemoryStream
         try {
-            $stream = New-Object System.IO.MemoryStream
+            $streamWriter = New-Object -TypeName System.IO.BinaryWriter -ArgumentList @($stream)
             try {
-                $streamWriter = New-Object -TypeName System.IO.BinaryWriter -ArgumentList @($stream)
-                try {
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## Bundle of CA Root Certificates`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## Certificate data from Windows $Source store as of: "))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes([datetime]::Now.ToString('R', [cultureinfo]'en-US')))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## Bundle of CA Root Certificates`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## Certificate data from Windows $Source store as of: "))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes([datetime]::Now.ToString('R', [cultureinfo]'en-US')))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## Conversion done with PhpManager`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## https://github.com/mlocati/powershell-phpmanager`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
+                $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
+                foreach ($cert in $certs) {
                     $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## Conversion done with PhpManager`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("## https://github.com/mlocati/powershell-phpmanager`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("##`n"))
-                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
-                    $counter = 0;
-                    foreach ($cert in $certs) {
-                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
-                        $name = $cert.FriendlyName
+                    $name = $cert.FriendlyName
+                    if (-not($name)) {
+                        $name = $cert.Issuer
                         if (-not($name)) {
-                            $name = $cert.Issuer
-                            if (-not($name)) {
-                                $name = ''
-                            }
+                            $name = ''
                         }
-                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes($name + "`n"))
-                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes('=' * $name.Length + "`n"))
-                        $crtFile = Join-Path -Path $tempDirectory -ChildPath "$counter.crt"
-                        Export-Certificate -FilePath $crtFile -Cert $cert -Type CERT | Out-Null
-                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("-----BEGIN CERTIFICATE-----`n"))
-                        $base64string = [Convert]::ToBase64String([IO.File]::ReadAllBytes($crtFile))
-                        $base64stringLength = $base64string.Length
-                        while ($base64stringLength -gt 64) {
-                            $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes($base64string.Substring(0, 64)))
-                            $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
-                            $base64string = $base64string.Substring(64)
-                            $base64stringLength = $base64stringLength - 64
-                        }
-                        if ($base64stringLength -gt 0) {
-                            $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes($base64string))
-                            $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
-                        }
-                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("-----END CERTIFICATE-----`n"))
-                        $counter++
                     }
-                    $result = $stream.ToArray()
-                } finally {
-                    $streamWriter.Dispose()
+                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes($name + "`n"))
+                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes('=' * $name.Length + "`n"))
+                    $certBytes = $cert.Export('Cert')
+                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("-----BEGIN CERTIFICATE-----`n"))
+                    $base64string = [Convert]::ToBase64String($certBytes)
+                    $base64stringLength = $base64string.Length
+                    while ($base64stringLength -gt 64) {
+                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes($base64string.Substring(0, 64)))
+                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
+                        $base64string = $base64string.Substring(64)
+                        $base64stringLength = $base64stringLength - 64
+                    }
+                    if ($base64stringLength -gt 0) {
+                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes($base64string))
+                        $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("`n"))
+                    }
+                    $streamWriter.Write([System.Text.Encoding]::ASCII.GetBytes("-----END CERTIFICATE-----`n"))
                 }
-            } finally {
-                $stream.Dispose()
+                $result = $stream.ToArray()
             }
-
-        } finally {
-            try {
-                Remove-Item -Path $tempDirectory -Recurse -Force
-            } catch {
-                Write-Debug 'Failed to remove a temporary directory'
+            finally {
+                $streamWriter.Dispose()
             }
         }
+        finally {
+            $stream.Dispose()
+        }
+
     }
     end {
         $result


### PR DESCRIPTION
Let's avoid using the `Export-Certificate` command when getting the certificates from Windows, because that command is defined in the PKI module, which is not available in PowerShell Core.