### PR TITLE
Fix installing xdebug

### DIFF
--- a/PhpManager/private/Constants.ps1
+++ b/PhpManager/private/Constants.ps1
@@ -59,3 +59,5 @@ New-Variable -Option Constant -Scope Script -Name 'CACERT_CHECKSUM_ALGORITHM' -V
 
 New-Variable -Option Constant -Scope Script -Name 'STATUS_DLL_NOT_FOUND' -Value 0xC0000135
 New-Variable -Option Constant -Scope Script -Name 'ENTRYPOINT_NOT_FOUND' -Value 0xC0000139
+
+New-Variable -Option Constant -Scope Script -Name 'PARSE_XDEBUG_WEBSITE' -Value $false

--- a/PhpManager/public/Install-PhpExtension.ps1
+++ b/PhpManager/public/Install-PhpExtension.ps1
@@ -93,6 +93,8 @@
                         if ($null -ne $availablePackageVersion) {
                             $remoteFileIsZip = $false
                             $finalDllName = 'php_xdebug.dll'
+                        } else {
+                            $finalDllName = $null
                         }
                     }
                     default {


### PR DESCRIPTION
Let's disable parsing the xdebug website directly; it contains broken links at the moment