### PR TITLE
Use master from @shivammathur

### DIFF
--- a/PhpManager/private/Constants.ps1
+++ b/PhpManager/private/Constants.ps1
@@ -25,6 +25,7 @@ New-Variable -Option Constant -Scope Script -Name 'UNSTABLEPHP_RX' -Value "$UNST
 
 New-Variable -Option Constant -Scope Script -Name 'RX_ZIPARCHIVE' -Value "php-(?<version>\d+\.\d+\.\d+)(?:(?<unstabilityLevel>$UNSTABLEPHP_RX)(?<unstabilityVersion>[1-9]\d*))?(?<threadSafe>-nts)?-Win32-(?:VC|vc|vs)(?<vcVersion>\d{1,2})-(?<architecture>x86|x64)\.zip"
 New-Variable -Option Constant -Scope Script -Name 'RX_ZIPARCHIVE_SNAPSHOT' -Value "/(?:master|(?:php-(?<version>\d+\.\d+)))/r[0-9a-f]{7,}/php-(?:master|\d+\.\d+)-(?<threadSafe>nts|ts)-windows-(?:VC|vc|vs)(?<vcVersion>\d{1,2})-(?<architecture>x86|x64)-r[0-9a-f]{7,}\.zip$"
+New-Variable -Option Constant -Scope Script -Name 'RX_ZIPARCHIVE_SNAPSHOT_SHIVAMMATHUR' -Value "/php-(?:master|\d+\.\d+)-(?<threadSafe>nts|ts)-windows-(?:VC|vc|vs)(?<vcVersion>\d{1,2})-(?<architecture>x86|x64).zip$"
 
 New-Variable -Option Constant -Scope Script -Name 'EXTENSIONSTATE_BUILTIN' -Value 'Builtin'
 New-Variable -Option Constant -Scope Script -Name 'EXTENSIONSTATE_UNKNOWN' -Value 'Unknown'

--- a/PhpManager/private/Get-PhpVersionFromUrl.ps1
+++ b/PhpManager/private/Get-PhpVersionFromUrl.ps1
@@ -45,6 +45,9 @@
             $data.Architecture = $groups['architecture'].Value
         } else {
             $match = $Url | Select-String -CaseSensitive -Pattern ($Script:RX_ZIPARCHIVE_SNAPSHOT)
+            if ($null -eq $match) {
+                $match = $Url | Select-String -CaseSensitive -Pattern ($Script:RX_ZIPARCHIVE_SNAPSHOT_SHIVAMMATHUR)
+            }
             if ($null -ne $match) {
                 $groups = $match.Matches[0].Groups
                 if ($groups['version'].Value -eq '') {

--- a/PhpManager/public/Get-PhpAvailableVersion.ps1
+++ b/PhpManager/public/Get-PhpAvailableVersion.ps1
@@ -101,6 +101,12 @@
                             }
                         }
                     }
+                    if ($true) {
+                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-nts-windows-vs16-x64.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-ts-windows-vs16-x64.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-nts-windows-vs16-x86.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-ts-windows-vs16-x86.zip' -ReleaseState $State
+                    }
                 }
                 default {
                     Set-NetSecurityProtocolType


### PR DESCRIPTION
Official PHP website doesn't offer Windows builds for PHP master anymore.

At https://windows.php.net/downloads/snaps/master/README.txt we read:

> windows.php.net currently does not provide snapshots for the master branch.
> Sorry for the inconvenience.
> There are community snapshots available, though:
> * <https://github.com/shivammathur/php-builder-windows/actions>
> Use at your own risk.