### PR TITLE
Switch from Bintray to GitHub releases for master

### DIFF
--- a/PhpManager/public/Get-PhpAvailableVersion.ps1
+++ b/PhpManager/public/Get-PhpAvailableVersion.ps1
@@ -102,10 +102,10 @@
                         }
                     }
                     if ($true) {
-                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-nts-windows-vs16-x64.zip' -ReleaseState $State
-                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-ts-windows-vs16-x64.zip' -ReleaseState $State
-                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-nts-windows-vs16-x86.zip' -ReleaseState $State
-                        $result += Get-PhpVersionFromUrl -Url 'https://dl.bintray.com/shivammathur/php/php-master-ts-windows-vs16-x86.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://github.com/shivammathur/php-builder-windows/releases/download/master/php-master-nts-windows-vs16-x64.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://github.com/shivammathur/php-builder-windows/releases/download/master/php-master-ts-windows-vs16-x64.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://github.com/shivammathur/php-builder-windows/releases/download/master/php-master-nts-windows-vs16-x86.zip' -ReleaseState $State
+                        $result += Get-PhpVersionFromUrl -Url 'https://github.com/shivammathur/php-builder-windows/releases/download/master/php-master-ts-windows-vs16-x86.zip' -ReleaseState $State
                     }
                 }
                 default {


### PR DESCRIPTION
Bintray will stop working from May 1<sup>st</sup>, 2021.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This PR switches to GitHub releases for master snaps