### PR TITLE
Call Install-PhpExtensionPrerequisite in Enable-PhpExtension

### DIFF
--- a/PhpManager/public/Enable-PhpExtension.ps1
+++ b/PhpManager/public/Enable-PhpExtension.ps1
@@ -125,6 +125,7 @@
                 if (-Not($found)) {
                     $newIniLines += "$iniKey=$newIniValue"
                 }
+                Install-PhpExtensionPrerequisite -PhpVersion $phpVersion -Extension $extensionToEnable
                 Set-PhpIniLine -Path $iniPath -Lines $newIniLines
                 $extensionToEnable.State = $Script:EXTENSIONSTATE_ENABLED
                 Write-Verbose ('The extension ' + $extensionToEnable.Name + ' v' + $extensionToEnable.Version + ' has been enabled')


### PR DESCRIPTION
This change would ensure that the dependencies for `imagick` are present before enabling it.

Fixes shivammathur/setup-php#455