### PR TITLE
Fix installing decimal extension

### DIFF
--- a/PhpManager/public/Install-PhpExtension.ps1
+++ b/PhpManager/public/Install-PhpExtension.ps1
@@ -176,6 +176,12 @@
                                     $additionalFiles += $libcouchbaseDll
                                 }
                             }
+                            'decimal' {
+                                $libmpdecDll = Join-Path -Path $tempFolder -ChildPath 'libmpdec.dll'
+                                if (Test-Path -LiteralPath $libmpdecDll -PathType Leaf) {
+                                    $additionalFiles += $libmpdecDll
+                                }
+                            }
                             'imagick' {
                                 $additionalFiles += @(Get-ChildItem -Path $tempFolder\CORE_*.dll -File -Depth 1)
                                 $additionalFiles += @(Get-ChildItem -Path $tempFolder\IM_*.dll -File -Depth 1)

--- a/test/tests/Install-Enable-Extensions.Tests.ps1
+++ b/test/tests/Install-Enable-Extensions.Tests.ps1
@@ -116,6 +116,15 @@
             $couchbase.Type | Should -BeExactly 'Php'
             $couchbase.State | Should -BeExactly 'Enabled'
         }
+        It -Name 'should download and install decimal on PHP <version>' -TestCases $testCases {
+            param ($path, $version)
+            Get-PhpExtension -Path $path | Where-Object { $_.Handle -eq 'decimal' } | Should -HaveCount 0
+            Install-PhpExtension -Extension decimal -Path $path
+            $decimal = Get-PhpExtension -Path $path | Where-Object { $_.Handle -eq 'decimal' }
+            $decimal | Should -HaveCount 1
+            $decimal.Type | Should -BeExactly 'Php'
+            $decimal.State | Should -BeExactly 'Enabled'
+        }
         It -Name 'should handle multiple extension versions' {
             $phpPath = Join-Path -Path $Global:PHPMANAGER_TESTINSTALLS -ChildPath (New-Guid).Guid
             Install-Php -Version 7.1 -Architecture x64 -ThreadSafe $true -Path $phpPath


### PR DESCRIPTION
This PR fixes installing decimal extension by adding `libmpdec.dll` from the extension zip.