### PR TITLE
Corrected misspelled handle

### DIFF
--- a/PhpManager/private/Get-PhpExtensionHandle.ps1
+++ b/PhpManager/private/Get-PhpExtensionHandle.ps1
@@ -33,7 +33,7 @@
             'advanced php debugger (apd)' { $handle = 'apd' }
             'nt user api' { $handle = 'ntuser' }
             'the ioncube php loader' { $handle = 'ioncube_loader' }
-            'ps/sc' { $handle = 'pssc' }
+            'pc/sc' { $handle = 'pcsc' }
             default {
                 $replaced = $handle -replace '\s+', '_'
                 if (-Not($replaced -match '^[a-z0-9][a-z0-9_\-]+$')) {


### PR DESCRIPTION
The new just added handle is not "PS/SC", the right name is "PC/SC"